### PR TITLE
ci: migrate PyPI upload to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,10 +1,6 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# This workflow will upload a Python Package to PyPI when a release is created.
+# Uses PyPI Trusted Publishers (OIDC) — no API token / repo secret required.
+# Setup on the PyPI side: https://docs.pypi.org/trusted-publishers/
 
 name: Upload Python Package
 
@@ -19,23 +15,29 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
+    # Required for PyPI Trusted Publishing via OIDC.
+    permissions:
+      id-token: write
+
+    # Optional but recommended: bind to a deployment environment so PyPI can
+    # require manual approval or restrict who can trigger publishes.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/regain
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The v0.4.0 release tried to publish to PyPI and got **403 Forbidden** — almost certainly a stale or wrongly-scoped \`PYPI_API_TOKEN\` secret. Rather than rotate the token, this PR migrates to PyPI's [Trusted Publishers](https://docs.pypi.org/trusted-publishers/) (OIDC), which doesn't use long-lived secrets at all.

## What changed

- Removed \`user: __token__\` / \`password: \${{ secrets.PYPI_API_TOKEN }}\`.
- Added \`permissions: id-token: write\` so GitHub Actions can mint an OIDC token.
- Bound the job to a \`pypi\` deployment environment so PyPI's policy and (optionally) a manual approval step can apply.
- Bumped \`actions/checkout@v3 → v4\`, \`actions/setup-python@v3 → v5\`, and pinned \`pypa/gh-action-pypi-publish\` to its \`release/v1\` branch (upstream's recommended ref for trusted publishing).

## Required PyPI-side setup (one-time)

This PR alone doesn't enable publishing — you also have to register the publisher on PyPI:

1. Go to https://pypi.org/manage/project/regain/settings/publishing/
2. Add a pending publisher with:
   - Owner: \`fdtomasi\`
   - Repository: \`regain\`
   - Workflow filename: \`python-publish.yml\`
   - Environment name: \`pypi\`
3. After merging this PR, either re-publish v0.4.0 from the GitHub Releases UI, or cut a new release / push a new tag.

## Cleanup after this works

- Delete the now-unused \`PYPI_API_TOKEN\` secret from repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)