### PR TITLE
ci: fix codecov uploads on master (token + v5)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,4 +42,7 @@ jobs:
         run: |
           pytest --cov=regain --cov-report=xml
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
## Why codecov is stuck at 43%

The matrix-update PR bumped \`codecov/codecov-action@v3 → v4\`, but v4 changed the rules: tokenless uploads only work on PR runs and forks; default-branch uploads require \`CODECOV_TOKEN\`. Every push to master since the bump logged

\`\`\`
warning - Branch \`master\` is protected but no token was provided
error   - Commit creating failed: {"message":"Token required because branch is protected"}
\`\`\`

so codecov is still showing the 43.44% reading from the last refactor/ktgl commit, even though the local suite reports 50% after the 55 new tests landed.

## What changed

- \`codecov/codecov-action@v4 → @v5\` (current latest)
- Pass \`token: \${{ secrets.CODECOV_TOKEN }}\` — empty on PR/fork runs (still tokenless), populated on master once the secret is added
- \`fail_ci_if_error: false\` so a transient codecov outage doesn't fail the build

## Required one-time setup

Add \`CODECOV_TOKEN\` as a repo secret:
1. https://codecov.io/gh/fdtomasi/regain/settings → copy the upload token
2. https://github.com/fdtomasi/regain/settings/secrets/actions → New secret \`CODECOV_TOKEN\`

Once the secret exists, the next push to master uploads coverage and the badge refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)