### PR TITLE
ci: drop codecov, use GitHub Actions native coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,6 +40,19 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          pytest --cov=regain --cov-report=xml
-      - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v4
+          pytest --cov=regain --cov-report=term --cov-report=html --cov-report=xml
+      - name: Coverage summary
+        if: always()
+        run: |
+          {
+            echo "### Coverage (Python ${{ matrix.python-version }})"
+            echo ""
+            coverage report --format=markdown
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload HTML coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-py${{ matrix.python-version }}
+          path: htmlcov/
+          retention-days: 14

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           pytest --cov=regain --cov-report=term --cov-report=html --cov-report=xml
       - name: Coverage summary
-        if: always()
+        if: always() && hashFiles('.coverage') != ''
         run: |
           {
             echo "### Coverage (Python ${{ matrix.python-version }})"
@@ -50,7 +50,7 @@ jobs:
             coverage report --format=markdown
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload HTML coverage report
-        if: always()
+        if: always() && hashFiles('htmlcov/index.html') != ''
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html-py${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![build](https://github.com/fdtomasi/regain/actions/workflows/python-package.yml/badge.svg)
-[![codecov](https://codecov.io/gh/fdtomasi/regain/branch/master/graph/badge.svg?token=1eLrec0OsI)](https://codecov.io/gh/fdtomasi/regain) [![licence](https://img.shields.io/badge/licence-BSD-blue.svg)](http://opensource.org/licenses/BSD-3-Clause) [![PyPI](https://img.shields.io/pypi/v/regain.svg)](https://pypi.python.org/pypi/regain) [![Conda](https://img.shields.io/conda/v/fdtomasi/regain.svg)](https://anaconda.org/fdtomasi/regain)
+[![licence](https://img.shields.io/badge/licence-BSD-blue.svg)](http://opensource.org/licenses/BSD-3-Clause) [![PyPI](https://img.shields.io/pypi/v/regain.svg)](https://pypi.python.org/pypi/regain) [![Conda](https://img.shields.io/conda/v/fdtomasi/regain.svg)](https://anaconda.org/fdtomasi/regain)
 
 # regain
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-codecov
 numpy>=2.2.6
 scipy>=1.15.3
 scikit-learn>=1.7.2


### PR DESCRIPTION
Supersedes #50. Removes the codecov dependency entirely and surfaces coverage natively through the Actions run page + an artifact.

## Why

The codecov upload has been silently broken on master since the action was bumped to v4 in the matrix migration: v4 dropped tokenless uploads on the default branch, so every push logged \`Token required because branch is protected\` and uploaded nothing. PR #50 fixed that by going to v5 + adding a \`CODECOV_TOKEN\` secret, but for a single-maintainer project the value of an external coverage service is low compared to the maintenance cost (token plumbing, action-version churn, occasional bot rate-limit issues).

## What changes

In \`.github/workflows/python-package.yml\`:
- Coverage is now reported three ways: \`term\` (in the log), \`html\` (uploaded as artifact), \`xml\` (kept for any future tool).
- A new step writes a markdown coverage table to \`$GITHUB_STEP_SUMMARY\` per matrix version, so the run page shows the per-file table inline.
- \`actions/upload-artifact@v4\` publishes \`htmlcov/\` for 14 days per Python version, so you can download and click through.
- codecov upload step removed.

Elsewhere:
- README: codecov badge removed.
- \`requirements.txt\`: \`codecov\` package removed (it was only ever a CI dep).

## What you lose

- Diff coverage in PR comments. For this project with one maintainer + mostly Dependabot PRs, this hasn't been valuable.
- The README badge. The badge has been wrong/red for months anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)