### PR TITLE
chore: drop stale AUTHORS.txt and root PR template

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,2 +1,0 @@
-Federico Tomasi [federico dot tomasi at dibris dot unige dot it]
-Veronica Tozzo [veronica dot tozzo at dibris dot unige dot it]

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,0 @@
-Fixes #.
-
-Proposed changes:
--
--
--
-
-


### PR DESCRIPTION
- **\`AUTHORS.txt\`**: two lines, both with dead DIBRIS emails. Authorship is already preserved in git history and in the README BibTeX citations.
- **\`PULL_REQUEST_TEMPLATE.md\`** (root): 36 bytes of minimal scaffolding (\`Fixes #.\` + bulleted \"Proposed changes:\"). Recent PR bodies have been more useful without it; if you want a template back later, \`.github/PULL_REQUEST_TEMPLATE.md\` is the right home.